### PR TITLE
update workflow actions versions

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout current repository to Master branch
-        uses: actions/checkout@v1
-      - name: Setup Nodejs 16.x
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v4
+      - name: Setup Nodejs 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
-      - name: Cachec dependencies and build outputs to improve workflow execution time.
-        uses: actions/cache@v1
+          node-version: "20.x"
+      - name: Cache dependencies and build outputs to improve workflow execution time.
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-js-{{ hashFiles('package-lock.json') }}

--- a/main.mustache
+++ b/main.mustache
@@ -19,6 +19,6 @@
 <hr />
 <p align="center">this <i>README</i> file is generated <b>every 3 hours</b>!
 </br>
-Last refresh: {{refresh_date}}
+Last refresh: {{refresh_date}} [![README build](https://github.com/pongpanott/pongpanott/actions/workflows/update-readme.yml/badge.svg?branch=master)](https://github.com/pongpanott/pongpanott/actions/workflows/update-readme.yml)
 
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and enhances the `README` file with a build status badge. The most important changes include upgrading the workflow dependencies to their latest versions and adding a dynamic badge to the `README` file to display the workflow status.

### Workflow updates:
* [`.github/workflows/update-readme.yml`](diffhunk://#diff-76f68b07de23d78ad2cc3e17967afcc8389e925a40d8c6b2e7f22bbe8fb6d872L16-R22): Upgraded `actions/checkout` from `v1` to `v4`, `actions/setup-node` from `v1` to `v4`, and updated the Node.js version from `16.x` to `20.x`. Also upgraded `actions/cache` from `v1` to `v4`.

### `README` enhancements:
* [`main.mustache`](diffhunk://#diff-846813cba74b7d337c4ecbe6e09f047c6c3734e3616a923b2ec378f2820819b7L22-R22): Added a dynamic badge to display the build status of the `update-readme.yml` workflow, linking to the workflow's status page.