### PR TITLE
add deployment script to report deployment status to discord channel

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -5,7 +5,7 @@ on:
     branch:
       - master
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: '0 */3 * * *'
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Nodejs 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: '20.x'
       - name: Cache dependencies and build outputs to improve workflow execution time.
         uses: actions/cache@v4
         with:
@@ -33,3 +33,12 @@ jobs:
         uses: mikeal/publish-to-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Report deployment status to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          STATUS="${{ job.status }}"
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"content": "🚀 README build workflow finished with status: **'$STATUS'** on branch `${{ github.ref }}`. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>"}' \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/update-readme.yml` with minor formatting changes and a new feature to report deployment status to Discord. The most notable change is the addition of the Discord notification step.

### Workflow Configuration Updates:

* Changed double quotes to single quotes in the `cron` schedule and `node-version` values for consistency. (`[[1]](diffhunk://#diff-76f68b07de23d78ad2cc3e17967afcc8389e925a40d8c6b2e7f22bbe8fb6d872L8-R8)`, `[[2]](diffhunk://#diff-76f68b07de23d78ad2cc3e17967afcc8389e925a40d8c6b2e7f22bbe8fb6d872L20-R20)`)

### New Feature:

* Added a step to report the deployment status to a Discord channel using a webhook. This step sends a message with the workflow status, branch, and run details. (`[.github/workflows/update-readme.ymlR36-R44](diffhunk://#diff-76f68b07de23d78ad2cc3e17967afcc8389e925a40d8c6b2e7f22bbe8fb6d872R36-R44)`)